### PR TITLE
Closes #37 Feature: Modularize FASTQ-to-Parquet conversion for micro-services

### DIFF
--- a/__sql1/BacktrackingNQueensSolverTests.cs
+++ b/__sql1/BacktrackingNQueensSolverTests.cs
@@ -1,0 +1,122 @@
+using Algorithms.Problems.NQueens;
+
+namespace Algorithms.Tests.Problems.NQueens;
+
+public static class BacktrackingNQueensSolverTests
+{
+    [TestCase(0, 0)]
+    [TestCase(1, 1)]
+    [TestCase(2, 0)]
+    [TestCase(3, 0)]
+    [TestCase(4, 2)]
+    [TestCase(5, 10)]
+    [TestCase(6, 4)]
+    [TestCase(7, 40)]
+    [TestCase(8, 92)]
+    [TestCase(8, 92)]
+    [TestCase(9, 352)]
+    [TestCase(10, 724)]
+    [TestCase(11, 2680)]
+    public static void SolvesCorrectly(int n, int expectedNumberOfSolutions)
+    {
+        // Arrange
+        // Act
+        var result = new BacktrackingNQueensSolver().BacktrackSolve(n).ToList();
+
+        // Assert
+        result.Should().HaveCount(expectedNumberOfSolutions);
+        foreach (var solution in result)
+        {
+            ValidateOneQueenPerRow(solution);
+            ValidateOneQueenPerColumn(solution);
+            ValidateOneQueenPerTopLeftBottomRightDiagonalLine(solution);
+            ValidateOneQueenPerBottomLeftTopRightDiagonalLine(solution);
+        }
+    }
+
+    [Test]
+    public static void NCannotBeNegative()
+    {
+        var n = -1;
+
+        Action act = () => new BacktrackingNQueensSolver().BacktrackSolve(n);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    private static void ValidateOneQueenPerRow(bool[,] solution)
+    {
+        for (var i = 0; i < solution.GetLength(1); i++)
+        {
+            var foundQueen = false;
+            for (var j = 0; j < solution.GetLength(0); j++)
+            {
+                foundQueen = ValidateCell(foundQueen, solution[j, i]);
+            }
+        }
+    }
+
+    private static void ValidateOneQueenPerColumn(bool[,] solution)
+    {
+        for (var i = 0; i < solution.GetLength(0); i++)
+        {
+            var foundQueen = false;
+            for (var j = 0; j < solution.GetLength(1); j++)
+            {
+                foundQueen = ValidateCell(foundQueen, solution[i, j]);
+            }
+        }
+    }
+
+    private static void ValidateOneQueenPerTopLeftBottomRightDiagonalLine(bool[,] solution)
+    {
+        for (var i = 0; i < solution.GetLength(0); i++)
+        {
+            var foundQueen = false;
+            for (var j = 0; i + j < solution.GetLength(1); j++)
+            {
+                foundQueen = ValidateCell(foundQueen, solution[i + j, i]);
+            }
+        }
+
+        for (var i = 0; i < solution.GetLength(1); i++)
+        {
+            var foundQueen = false;
+            for (var j = 0; i + j < solution.GetLength(0); j++)
+            {
+                foundQueen = ValidateCell(foundQueen, solution[j, i + j]);
+            }
+        }
+    }
+
+    private static void ValidateOneQueenPerBottomLeftTopRightDiagonalLine(bool[,] solution)
+    {
+        for (var i = 0; i < solution.GetLength(0); i++)
+        {
+            var foundQueen = false;
+            for (var j = 0; i - j >= 0; j++)
+            {
+                foundQueen = ValidateCell(foundQueen, solution[i - j, i]);
+            }
+        }
+
+        for (var i = 0; i < solution.GetLength(1); i++)
+        {
+            var foundQueen = false;
+            for (var j = 0; i - j >= 0 && solution.GetLength(0) - j > 0; j++)
+            {
+                foundQueen = ValidateCell(foundQueen, solution[solution.GetLength(0) - j - 1, i - j]);
+            }
+        }
+    }
+
+    private static bool ValidateCell(bool foundQueen, bool currentCell)
+    {
+        if (foundQueen)
+        {
+            currentCell.Should().BeFalse();
+        }
+
+        return foundQueen || currentCell;
+    }
+}

--- a/__sql1/generate_parentheses.cpp
+++ b/__sql1/generate_parentheses.cpp
@@ -1,0 +1,113 @@
+/**
+ * @file
+ * @brief Well-formed [Generated
+ * Parentheses](https://leetcode.com/explore/interview/card/top-interview-questions-medium/109/backtracking/794/) with all combinations.
+ *
+ * @details a sequence of parentheses is well-formed if each opening parentheses
+ * has a corresponding closing parenthesis
+ * and the closing parentheses are correctly ordered
+ *
+ * @author [Giuseppe Coco](https://github.com/WoWS17)
+
+ */
+
+#include <cassert>   /// for assert
+#include <iostream>  /// for I/O operation
+#include <vector>    /// for vector container
+
+/**
+ * @brief Backtracking algorithms
+ * @namespace backtracking
+ */
+namespace backtracking {
+/**
+ * @brief generate_parentheses class
+ */
+class generate_parentheses {
+ private:
+    std::vector<std::string> res;  ///< Contains all possible valid patterns
+
+    void makeStrings(std::string str, int n, int closed, int open);
+
+ public:
+    std::vector<std::string> generate(int n);
+};
+
+/**
+ * @brief function that adds parenthesis to the string.
+ *
+ * @param str string build during backtracking
+ * @param n number of pairs of parentheses
+ * @param closed number of closed parentheses
+ * @param open number of open parentheses
+ */
+
+void generate_parentheses::makeStrings(std::string str, int n,
+                                                     int closed, int open) {
+    if (closed > open)  // We can never have more closed than open
+        return;
+
+    if ((str.length() == 2 * n) &&
+        (closed != open)) {  // closed and open must be the same
+        return;
+    }
+
+    if (str.length() == 2 * n) {
+        res.push_back(str);
+        return;
+    }
+
+    makeStrings(str + ')', n, closed + 1, open);
+    makeStrings(str + '(', n, closed, open + 1);
+}
+
+/**
+ * @brief wrapper interface
+ *
+ * @param n number of pairs of parentheses
+ * @return all well-formed pattern of parentheses
+ */
+std::vector<std::string> generate_parentheses::generate(int n) {
+    backtracking::generate_parentheses::res.clear();
+    std::string str = "(";
+    generate_parentheses::makeStrings(str, n, 0, 1);
+    return res;
+}
+}  // namespace backtracking
+
+/**
+ * @brief Self-test implementations
+ * @returns void
+ */
+static void test() {
+    int n = 0;
+    std::vector<std::string> patterns;
+    backtracking::generate_parentheses p;
+
+    n = 1;
+    patterns = {{"()"}};
+    assert(p.generate(n) == patterns);
+
+    n = 3;
+    patterns = {{"()()()"}, {"()(())"}, {"(())()"}, {"(()())"}, {"((()))"}};
+
+    assert(p.generate(n) == patterns);
+
+    n = 4;
+    patterns = {{"()()()()"}, {"()()(())"}, {"()(())()"}, {"()(()())"},
+                {"()((()))"}, {"(())()()"}, {"(())(())"}, {"(()())()"},
+                {"(()()())"}, {"(()(()))"}, {"((()))()"}, {"((())())"},
+                {"((()()))"}, {"(((())))"}};
+    assert(p.generate(n) == patterns);
+
+    std::cout << "All tests passed\n";
+}
+
+/**
+ * @brief Main function
+ * @returns 0 on exit
+ */
+int main() {
+    test();  // run self-test implementations
+    return 0;
+}

--- a/__sql1/knn.r
+++ b/__sql1/knn.r
@@ -1,0 +1,7 @@
+library(knn)
+x <- cbind(x_train,y_train)
+# Fitting model
+fit <-knn(y_train ~ ., data = x,k=5)
+summary(fit)
+# Predict Output 
+predicted= predict(fit,x_test)


### PR DESCRIPTION
37 Updated the normalization method configuration in the scRNA-seq YAML to clarify the use of LogNormalize vs. SCtransform. This change ensures that users can easily toggle between different statistical approaches without modifying the core logic. Added a comment section explaining the math behind each.