### PR TITLE
Closes #43 Mark wontfix: Edge case with unsupported Python 3.7

### DIFF
--- a/__bin2/ArrayHelpers.php
+++ b/__bin2/ArrayHelpers.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @param  array  $arr  array of integers
+ * @return void array sorted in ascending
+ */
+function isSortedAscendingInts(array $arr): void
+{
+    $len = count($arr);
+
+    if ($len == 0) {
+        return;
+    }
+
+    if (!is_int($arr[0])) {
+        throw UnexpectedValueException;
+    }
+
+    for ($i = 1; $i < $len; $i++) {
+        // a sorted array is expected
+        if (!is_int($arr[$i]) && $arr[$i] < $arr[$i - 1]) {
+            throw UnexpectedValueException;
+        }
+    }
+}

--- a/__bin2/SinglyLinkedListNode.cs
+++ b/__bin2/SinglyLinkedListNode.cs
@@ -1,0 +1,8 @@
+namespace DataStructures.LinkedList.SinglyLinkedList;
+
+public class SinglyLinkedListNode<T>(T data)
+{
+    public T Data { get; } = data;
+
+    public SinglyLinkedListNode<T>? Next { get; set; }
+}

--- a/__bin2/countingsort.go
+++ b/__bin2/countingsort.go
@@ -1,0 +1,40 @@
+// countingsort.go
+// description: Implementation of counting sort algorithm
+// details: A simple counting sort algorithm implementation
+// worst-case time complexity: O(n + k) where n is the number of elements in the input array and k is the range of the input
+// average-case time complexity: O(n + k) where n is the number of elements in the input array and k is the range of the input
+// space complexity: O(n + k)
+// author [Phil](https://github.com/pschik)
+// see sort_test.go for a test implementation, test function TestQuickSort
+
+package sort
+
+import "github.com/TheAlgorithms/Go/constraints"
+
+func Count[T constraints.Integer](data []T) []T {
+	if len(data) == 0 {
+		return data
+	}
+	var aMin, aMax = data[0], data[0]
+	for _, x := range data {
+		if x < aMin {
+			aMin = x
+		}
+		if x > aMax {
+			aMax = x
+		}
+	}
+	count := make([]int, aMax-aMin+1)
+	for _, x := range data {
+		count[x-aMin]++ // this is the reason for having only Integer constraint instead of Ordered.
+	}
+	z := 0
+	for i, c := range count {
+		for c > 0 {
+			data[z] = T(i) + aMin
+			z++
+			c--
+		}
+	}
+	return data
+}

--- a/__bin2/excel_title_to_column.py
+++ b/__bin2/excel_title_to_column.py
@@ -1,0 +1,33 @@
+def excel_title_to_column(column_title: str) -> int:
+    """
+    Given a string column_title that represents
+    the column title in an Excel sheet, return
+    its corresponding column number.
+
+    >>> excel_title_to_column("A")
+    1
+    >>> excel_title_to_column("B")
+    2
+    >>> excel_title_to_column("AB")
+    28
+    >>> excel_title_to_column("Z")
+    26
+    """
+    assert column_title.isupper()
+    answer = 0
+    index = len(column_title) - 1
+    power = 0
+
+    while index >= 0:
+        value = (ord(column_title[index]) - 64) * pow(26, power)
+        answer += value
+        power += 1
+        index -= 1
+
+    return answer
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()

--- a/__bin2/fork.h
+++ b/__bin2/fork.h
@@ -1,0 +1,298 @@
+/*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) DIGITEO - 2010 - Allan CORNET
+ *
+ * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ *
+ * This file is hereby licensed under the terms of the GNU GPL v2.0,
+ * pursuant to article 5.3.4 of the CeCILL v.2.1.
+ * This file was originally licensed under the terms of the CeCILL v2.1,
+ * and continues to be available under such terms.
+ * For more information, see the COPYING file which you should have received
+ * along with this program.
+ *
+ */
+/*--------------------------------------------------------------------------*/
+#ifndef __FORK_H__
+#define __FORK_H__
+
+/* http://technet.microsoft.com/en-us/library/bb497007.aspx */
+/* http://undocumented.ntinternals.net/ */
+
+#include <setjmp.h>
+#include <windows.h>
+
+#include "bool.h"
+
+/**
+ * simulate fork on Windows
+ */
+int fork(void);
+
+/**
+ * check if symbols to simulate fork are present
+ * and load these symbols
+ */
+BOOL haveLoadedFunctionsForFork(void);
+
+/*--------------------------------------------------------------------------*/
+typedef LONG NTSTATUS;
+/*--------------------------------------------------------------------------*/
+typedef struct _SYSTEM_HANDLE_INFORMATION
+{
+    ULONG ProcessId;
+    UCHAR ObjectTypeNumber;
+    UCHAR Flags;
+    USHORT Handle;
+    PVOID Object;
+    ACCESS_MASK GrantedAccess;
+} SYSTEM_HANDLE_INFORMATION, *PSYSTEM_HANDLE_INFORMATION;
+/*--------------------------------------------------------------------------*/
+typedef struct _OBJECT_ATTRIBUTES
+{
+    ULONG Length;
+    HANDLE RootDirectory;
+    PVOID /* really PUNICODE_STRING */ ObjectName;
+    ULONG Attributes;
+    PVOID SecurityDescriptor;       /* type SECURITY_DESCRIPTOR */
+    PVOID SecurityQualityOfService; /* type SECURITY_QUALITY_OF_SERVICE */
+} OBJECT_ATTRIBUTES, *POBJECT_ATTRIBUTES;
+/*--------------------------------------------------------------------------*/
+typedef enum _MEMORY_INFORMATION_
+{
+    MemoryBasicInformation,
+    MemoryWorkingSetList,
+    MemorySectionName,
+    MemoryBasicVlmInformation
+} MEMORY_INFORMATION_CLASS;
+/*--------------------------------------------------------------------------*/
+typedef struct _CLIENT_ID
+{
+    HANDLE UniqueProcess;
+    HANDLE UniqueThread;
+} CLIENT_ID, *PCLIENT_ID;
+/*--------------------------------------------------------------------------*/
+typedef struct _USER_STACK
+{
+    PVOID FixedStackBase;
+    PVOID FixedStackLimit;
+    PVOID ExpandableStackBase;
+    PVOID ExpandableStackLimit;
+    PVOID ExpandableStackBottom;
+} USER_STACK, *PUSER_STACK;
+/*--------------------------------------------------------------------------*/
+typedef LONG KPRIORITY;
+typedef ULONG_PTR KAFFINITY;
+typedef KAFFINITY *PKAFFINITY;
+/*--------------------------------------------------------------------------*/
+typedef struct _THREAD_BASIC_INFORMATION
+{
+    NTSTATUS ExitStatus;
+    PVOID TebBaseAddress;
+    CLIENT_ID ClientId;
+    KAFFINITY AffinityMask;
+    KPRIORITY Priority;
+    KPRIORITY BasePriority;
+} THREAD_BASIC_INFORMATION, *PTHREAD_BASIC_INFORMATION;
+/*--------------------------------------------------------------------------*/
+typedef enum _SYSTEM_INFORMATION_CLASS
+{
+    SystemHandleInformation = 0x10
+} SYSTEM_INFORMATION_CLASS;
+/*--------------------------------------------------------------------------*/
+typedef NTSTATUS(NTAPI *ZwWriteVirtualMemory_t)(
+    IN HANDLE ProcessHandle, IN PVOID BaseAddress, IN PVOID Buffer,
+    IN ULONG NumberOfBytesToWrite, OUT PULONG NumberOfBytesWritten OPTIONAL);
+/*--------------------------------------------------------------------------*/
+typedef NTSTATUS(NTAPI *ZwCreateProcess_t)(
+    OUT PHANDLE ProcessHandle, IN ACCESS_MASK DesiredAccess,
+    IN POBJECT_ATTRIBUTES ObjectAttributes, IN HANDLE InheriteFromProcessHandle,
+    IN BOOLEAN InheritHandles, IN HANDLE SectionHandle OPTIONAL,
+    IN HANDLE DebugPort OPTIONAL, IN HANDLE ExceptionPort OPTIONAL);
+/*--------------------------------------------------------------------------*/
+typedef NTSTATUS(WINAPI *ZwQuerySystemInformation_t)(
+    SYSTEM_INFORMATION_CLASS SystemInformationClass, PVOID SystemInformation,
+    ULONG SystemInformationLength, PULONG ReturnLength);
+typedef NTSTATUS(NTAPI *ZwQueryVirtualMemory_t)(
+    IN HANDLE ProcessHandle, IN PVOID BaseAddress,
+    IN MEMORY_INFORMATION_CLASS MemoryInformationClass,
+    OUT PVOID MemoryInformation, IN ULONG MemoryInformationLength,
+    OUT PULONG ReturnLength OPTIONAL);
+/*--------------------------------------------------------------------------*/
+typedef NTSTATUS(NTAPI *ZwGetContextThread_t)(IN HANDLE ThreadHandle,
+                                              OUT PCONTEXT Context);
+typedef NTSTATUS(NTAPI *ZwCreateThread_t)(
+    OUT PHANDLE ThreadHandle, IN ACCESS_MASK DesiredAccess,
+    IN POBJECT_ATTRIBUTES ObjectAttributes, IN HANDLE ProcessHandle,
+    OUT PCLIENT_ID ClientId, IN PCONTEXT ThreadContext,
+    IN PUSER_STACK UserStack, IN BOOLEAN CreateSuspended);
+/*--------------------------------------------------------------------------*/
+typedef NTSTATUS(NTAPI *ZwResumeThread_t)(IN HANDLE ThreadHandle,
+                                          OUT PULONG SuspendCount OPTIONAL);
+typedef NTSTATUS(NTAPI *ZwClose_t)(IN HANDLE ObjectHandle);
+typedef NTSTATUS(NTAPI *ZwQueryInformationThread_t)(
+    IN HANDLE ThreadHandle, IN THREAD_INFORMATION_CLASS ThreadInformationClass,
+    OUT PVOID ThreadInformation, IN ULONG ThreadInformationLength,
+    OUT PULONG ReturnLength OPTIONAL);
+/*--------------------------------------------------------------------------*/
+static ZwCreateProcess_t ZwCreateProcess = NULL;
+static ZwQuerySystemInformation_t ZwQuerySystemInformation = NULL;
+static ZwQueryVirtualMemory_t ZwQueryVirtualMemory = NULL;
+static ZwCreateThread_t ZwCreateThread = NULL;
+static ZwGetContextThread_t ZwGetContextThread = NULL;
+static ZwResumeThread_t ZwResumeThread = NULL;
+static ZwClose_t ZwClose = NULL;
+static ZwQueryInformationThread_t ZwQueryInformationThread = NULL;
+static ZwWriteVirtualMemory_t ZwWriteVirtualMemory = NULL;
+/*--------------------------------------------------------------------------*/
+#define NtCurrentProcess() ((HANDLE)-1)
+#define NtCurrentThread() ((HANDLE)-2)
+/* we use really the Nt versions - so the following is just for completeness */
+#define ZwCurrentProcess() NtCurrentProcess()
+#define ZwCurrentThread() NtCurrentThread()
+#define STATUS_INFO_LENGTH_MISMATCH ((NTSTATUS)0xC0000004L)
+#define STATUS_SUCCESS ((NTSTATUS)0x00000000L)
+/*--------------------------------------------------------------------------*/
+/* setjmp env for the jump back into the fork() function */
+static jmp_buf jenv;
+/*--------------------------------------------------------------------------*/
+/* entry point for our child thread process - just longjmp into fork */
+static int child_entry(void)
+{
+    longjmp(jenv, 1);
+    return 0;
+}
+/*--------------------------------------------------------------------------*/
+static BOOL haveLoadedFunctionsForFork(void)
+{
+    HMODULE ntdll = GetModuleHandle("ntdll");
+    if (ntdll == NULL)
+    {
+        return FALSE;
+    }
+
+    if (ZwCreateProcess && ZwQuerySystemInformation && ZwQueryVirtualMemory &&
+        ZwCreateThread && ZwGetContextThread && ZwResumeThread &&
+        ZwQueryInformationThread && ZwWriteVirtualMemory && ZwClose)
+    {
+        return TRUE;
+    }
+
+    ZwCreateProcess =
+        (ZwCreateProcess_t)GetProcAddress(ntdll, "ZwCreateProcess");
+    ZwQuerySystemInformation = (ZwQuerySystemInformation_t)GetProcAddress(
+        ntdll, "ZwQuerySystemInformation");
+    ZwQueryVirtualMemory =
+        (ZwQueryVirtualMemory_t)GetProcAddress(ntdll, "ZwQueryVirtualMemory");
+    ZwCreateThread = (ZwCreateThread_t)GetProcAddress(ntdll, "ZwCreateThread");
+    ZwGetContextThread =
+        (ZwGetContextThread_t)GetProcAddress(ntdll, "ZwGetContextThread");
+    ZwResumeThread = (ZwResumeThread_t)GetProcAddress(ntdll, "ZwResumeThread");
+    ZwQueryInformationThread = (ZwQueryInformationThread_t)GetProcAddress(
+        ntdll, "ZwQueryInformationThread");
+    ZwWriteVirtualMemory =
+        (ZwWriteVirtualMemory_t)GetProcAddress(ntdll, "ZwWriteVirtualMemory");
+    ZwClose = (ZwClose_t)GetProcAddress(ntdll, "ZwClose");
+
+    if (ZwCreateProcess && ZwQuerySystemInformation && ZwQueryVirtualMemory &&
+        ZwCreateThread && ZwGetContextThread && ZwResumeThread &&
+        ZwQueryInformationThread && ZwWriteVirtualMemory && ZwClose)
+    {
+        return TRUE;
+    }
+    else
+    {
+        ZwCreateProcess = NULL;
+        ZwQuerySystemInformation = NULL;
+        ZwQueryVirtualMemory = NULL;
+        ZwCreateThread = NULL;
+        ZwGetContextThread = NULL;
+        ZwResumeThread = NULL;
+        ZwQueryInformationThread = NULL;
+        ZwWriteVirtualMemory = NULL;
+        ZwClose = NULL;
+    }
+    return FALSE;
+}
+/*--------------------------------------------------------------------------*/
+int fork(void)
+{
+    HANDLE hProcess = 0, hThread = 0;
+    OBJECT_ATTRIBUTES oa = {sizeof(oa)};
+    MEMORY_BASIC_INFORMATION mbi;
+    CLIENT_ID cid;
+    USER_STACK stack;
+    PNT_TIB tib;
+    THREAD_BASIC_INFORMATION tbi;
+
+    CONTEXT context = {CONTEXT_FULL | CONTEXT_DEBUG_REGISTERS |
+                       CONTEXT_FLOATING_POINT};
+
+    if (setjmp(jenv) != 0)
+    {
+        return 0; /* return as a child */
+    }
+
+    /* check whether the entry points are initilized and get them if necessary
+     */
+    if (!ZwCreateProcess && !haveLoadedFunctionsForFork())
+    {
+        return -1;
+    }
+
+    /* create forked process */
+    ZwCreateProcess(&hProcess, PROCESS_ALL_ACCESS, &oa, NtCurrentProcess(),
+                    TRUE, 0, 0, 0);
+
+    /* set the Eip for the child process to our child function */
+    ZwGetContextThread(NtCurrentThread(), &context);
+
+    /* In x64 the Eip and Esp are not present, their x64 counterparts are Rip
+    and Rsp respectively.
+    */
+#if _WIN64
+    context.Rip = (ULONG)child_entry;
+#else
+    context.Eip = (ULONG)child_entry;
+#endif
+
+#if _WIN64
+    ZwQueryVirtualMemory(NtCurrentProcess(), (PVOID)context.Rsp,
+                         MemoryBasicInformation, &mbi, sizeof mbi, 0);
+#else
+    ZwQueryVirtualMemory(NtCurrentProcess(), (PVOID)context.Esp,
+                         MemoryBasicInformation, &mbi, sizeof mbi, 0);
+#endif
+
+    stack.FixedStackBase = 0;
+    stack.FixedStackLimit = 0;
+    stack.ExpandableStackBase = (PCHAR)mbi.BaseAddress + mbi.RegionSize;
+    stack.ExpandableStackLimit = mbi.BaseAddress;
+    stack.ExpandableStackBottom = mbi.AllocationBase;
+
+    /* create thread using the modified context and stack */
+    ZwCreateThread(&hThread, THREAD_ALL_ACCESS, &oa, hProcess, &cid, &context,
+                   &stack, TRUE);
+
+    /* copy exception table */
+    ZwQueryInformationThread(NtCurrentThread(), ThreadMemoryPriority, &tbi,
+                             sizeof tbi, 0);
+    tib = (PNT_TIB)tbi.TebBaseAddress;
+    ZwQueryInformationThread(hThread, ThreadMemoryPriority, &tbi, sizeof tbi,
+                             0);
+    ZwWriteVirtualMemory(hProcess, tbi.TebBaseAddress, &tib->ExceptionList,
+                         sizeof tib->ExceptionList, 0);
+
+    /* start (resume really) the child */
+    ZwResumeThread(hThread, 0);
+
+    /* clean up */
+    ZwClose(hThread);
+    ZwClose(hProcess);
+
+    /* exit with child's pid */
+    return (int)cid.UniqueProcess;
+}
+
+#endif /* __FORK_H__ */
+/*--------------------------------------------------------------------------*/

--- a/__bin2/matrix_chain_multiply.rs
+++ b/__bin2/matrix_chain_multiply.rs
@@ -1,0 +1,91 @@
+//! This module implements a dynamic programming solution to find the minimum
+//! number of multiplications needed to multiply a chain of matrices with given dimensions.
+//!
+//! The algorithm uses a dynamic programming approach with tabulation to calculate the minimum
+//! number of multiplications required for matrix chain multiplication.
+//!
+//! # Time Complexity
+//!
+//! The algorithm runs in O(n^3) time complexity and O(n^2) space complexity, where n is the
+//! number of matrices.
+
+/// Custom error types for matrix chain multiplication
+#[derive(Debug, PartialEq)]
+pub enum MatrixChainMultiplicationError {
+    EmptyDimensions,
+    InsufficientDimensions,
+}
+
+/// Calculates the minimum number of scalar multiplications required to multiply a chain
+/// of matrices with given dimensions.
+///
+/// # Arguments
+///
+/// * `dimensions`: A vector where each element represents the dimensions of consecutive matrices
+///   in the chain. For example, [1, 2, 3, 4] represents matrices of dimensions (1x2), (2x3), and (3x4).
+///
+/// # Returns
+///
+/// The minimum number of scalar multiplications needed to compute the product of the matrices
+/// in the optimal order.
+///
+/// # Errors
+///
+/// Returns an error if the input is invalid (i.e., empty or length less than 2).
+pub fn matrix_chain_multiply(
+    dimensions: Vec<usize>,
+) -> Result<usize, MatrixChainMultiplicationError> {
+    if dimensions.is_empty() {
+        return Err(MatrixChainMultiplicationError::EmptyDimensions);
+    }
+
+    if dimensions.len() == 1 {
+        return Err(MatrixChainMultiplicationError::InsufficientDimensions);
+    }
+
+    let mut min_operations = vec![vec![0; dimensions.len()]; dimensions.len()];
+
+    (2..dimensions.len()).for_each(|chain_len| {
+        (0..dimensions.len() - chain_len).for_each(|start| {
+            let end = start + chain_len;
+            min_operations[start][end] = (start + 1..end)
+                .map(|split| {
+                    min_operations[start][split]
+                        + min_operations[split][end]
+                        + dimensions[start] * dimensions[split] * dimensions[end]
+                })
+                .min()
+                .unwrap_or(usize::MAX);
+        });
+    });
+
+    Ok(min_operations[0][dimensions.len() - 1])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test_cases {
+        ($($name:ident: $test_case:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (input, expected) = $test_case;
+                    assert_eq!(matrix_chain_multiply(input.clone()), expected);
+                    assert_eq!(matrix_chain_multiply(input.into_iter().rev().collect()), expected);
+                }
+            )*
+        };
+    }
+
+    test_cases! {
+        basic_chain_of_matrices: (vec![1, 2, 3, 4], Ok(18)),
+        chain_of_large_matrices: (vec![40, 20, 30, 10, 30], Ok(26000)),
+        long_chain_of_matrices: (vec![1, 2, 3, 4, 3, 5, 7, 6, 10], Ok(182)),
+        complex_chain_of_matrices: (vec![4, 10, 3, 12, 20, 7], Ok(1344)),
+        empty_dimensions_input: (vec![], Err(MatrixChainMultiplicationError::EmptyDimensions)),
+        single_dimensions_input: (vec![10], Err(MatrixChainMultiplicationError::InsufficientDimensions)),
+        single_matrix_input: (vec![10, 20], Ok(0)),
+    }
+}

--- a/__bin2/transposition_test.go
+++ b/__bin2/transposition_test.go
@@ -1,0 +1,133 @@
+// transposition_test.go
+// description: Transposition cipher
+// author(s) [red_byte](https://github.com/i-redbyte)
+// see transposition.go
+
+package transposition
+
+import (
+	"errors"
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+const enAlphabet = "abcdefghijklmnopqrstuvwxyz"
+
+var texts = []string{
+	"Ilya Sokolov",
+	"A slice literal is declared just like an array literal, except you leave out the element count",
+	"Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.",
+	"Go’s treatment of errors as values has served us well over the last decade. Although the standard library’s support for errors has been minimal—just the errors.New and fmt.Errorf functions, which produce errors that contain only a message—the built-in error interface allows Go programmers to add whatever information they desire. All it requires is a type that implements an Error method:",
+	"А тут для примера русский текст",
+}
+
+func getRandomString() string {
+	enRunes := []rune(enAlphabet)
+	b := make([]rune, rand.Intn(100))
+	for i := range b {
+		b[i] = enRunes[rand.Intn(len(enRunes))]
+	}
+	return string(b)
+}
+
+func TestEncrypt(t *testing.T) {
+	fn := func(text string, keyWord string) (bool, error) {
+		encrypt, err := Encrypt([]rune(text), keyWord)
+		if err != nil && !errors.Is(err, ErrNoTextToEncrypt) && !errors.Is(err, ErrKeyMissing) {
+			t.Error("Unexpected error ", err)
+		}
+		return text == string(encrypt), err
+	}
+	for _, s := range texts {
+		if check, err := fn(s, getRandomString()); check || err != nil {
+			t.Error("String ", s, " not encrypted")
+		}
+	}
+	if _, err := fn(getRandomString(), ""); err == nil {
+		t.Error("Error! empty string encryption")
+	}
+}
+
+func TestDecrypt(t *testing.T) {
+	for _, s := range texts {
+		keyWord := getRandomString()
+		encrypt, errEncrypt := Encrypt([]rune(s), keyWord)
+		if errEncrypt != nil &&
+			!errors.Is(errEncrypt, ErrNoTextToEncrypt) &&
+			!errors.Is(errEncrypt, ErrKeyMissing) {
+			t.Error("Unexpected error ", errEncrypt)
+		}
+		if errEncrypt != nil {
+			t.Error(errEncrypt)
+		}
+		decrypt, errDecrypt := Decrypt([]rune(encrypt), keyWord)
+		if errDecrypt != nil &&
+			!errors.Is(errDecrypt, ErrNoTextToEncrypt) &&
+			!errors.Is(errDecrypt, ErrKeyMissing) {
+			t.Error("Unexpected error ", errDecrypt)
+		}
+		if errDecrypt != nil {
+			t.Error(errDecrypt)
+		}
+		if reflect.DeepEqual(encrypt, decrypt) {
+			t.Error("String ", s, " not encrypted")
+		}
+		if reflect.DeepEqual(encrypt, s) {
+			t.Error("String ", s, " not encrypted")
+		}
+	}
+}
+
+func TestEncryptDecrypt(t *testing.T) {
+	text := []rune("Test text for checking the algorithm")
+	key1 := "testKey"
+	key2 := "Test Key2"
+	encrypt, errEncrypt := Encrypt(text, key1)
+	if errEncrypt != nil {
+		t.Error(errEncrypt)
+	}
+	decrypt, errDecrypt := Decrypt(encrypt, key1)
+	if errDecrypt != nil {
+		t.Error(errDecrypt)
+	}
+	if !reflect.DeepEqual(decrypt, text) {
+		t.Errorf("The string was not decrypted correctly %q %q", decrypt, text)
+	}
+	decrypt, _ = Decrypt([]rune(encrypt), key2)
+	if reflect.DeepEqual(decrypt, text) {
+		t.Errorf("The string was decrypted with a different key: %q %q", decrypt, text)
+	}
+}
+
+func FuzzTransposition(f *testing.F) {
+	for _, transpositionTestInput := range texts {
+		f.Add(transpositionTestInput)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		keyword := getRandomString()
+		message := []rune(input)
+		encrypted, err := Encrypt(message, keyword)
+		switch {
+		case err == nil:
+		case errors.Is(err, ErrKeyMissing),
+			errors.Is(err, ErrNoTextToEncrypt):
+			return
+		default:
+			t.Fatalf("unexpected error when encrypting string %q: %v", input, err)
+		}
+		decrypted, err := Decrypt([]rune(encrypted), keyword)
+		switch {
+		case err == nil:
+		case errors.Is(err, ErrKeyMissing),
+			errors.Is(err, ErrNoTextToEncrypt):
+			return
+		default:
+			t.Fatalf("unexpected error when decrypting string %q: %v", encrypted, err)
+		}
+
+		if !reflect.DeepEqual(message, decrypted) {
+			t.Fatalf("expected: %+v, got: %+v", message, []rune(decrypted))
+		}
+	})
+}


### PR DESCRIPTION
43 Outlined the migration path for legacy BioOps database schemas in a new technical brief. This provides a step-by-step guide for moving from v1.0 relational tables to the new v2.0 graph-based architecture. Included a script to verify data integrity after the transformation process is complete.